### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,13 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.3
         with:
           # This path is specific to Ubuntu
           path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,5 +4,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.UPDATER_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)** on 2025-01-28T03:28:18Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
